### PR TITLE
Added command lines of building Android project

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ You can also create a JS project or Lua project with `-l js` or `-l lua`.
 
     $ cocos run -p android -j 4
 
+### Build a new project for Android ###
+
+    $ cd NEW_PROJECTS_DIR/proj.android
+    $ python ./build_native.py
+
+### Build a new project for Android Studio ###
+
+    $ cocos compile -p android --android-studio
+
 ### Build and run a new project for iOS ###
 
     $ cocos run -p ios


### PR DESCRIPTION
It's weird to build and run Android project with command line as followed
``$ cocos run -p android -j 4``
It seems didn't work for me.
I prefer to use Android Studio  when I try to build a Android project,and I can only build it and import it to Android Studio and run successfully with those command lines I added.
So I think that those command lines should be showed directly to who need them. 